### PR TITLE
feat(SPV-1084): ARC policy service

### DIFF
--- a/engine/chain/chain_service.go
+++ b/engine/chain/chain_service.go
@@ -1,18 +1,22 @@
 package chain
 
 import (
+	"github.com/bitcoin-sv/spv-wallet/engine/chain/internal/policy"
 	"github.com/bitcoin-sv/spv-wallet/engine/chain/internal/query"
+	"github.com/bitcoin-sv/spv-wallet/engine/chain/models"
 	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog"
 )
 
 type chainService struct {
 	QueryService
+	PolicyService
 }
 
 // NewChainService creates a new chain service.
-func NewChainService(logger zerolog.Logger, httpClient *resty.Client, arcURL, arcToken, deploymentID string) Service {
+func NewChainService(logger zerolog.Logger, httpClient *resty.Client, arcCfg chainmodels.ARCConfig) Service {
 	return &chainService{
-		query.NewQueryService(logger.With().Str("chain", "query").Logger(), httpClient, arcURL, arcToken, deploymentID),
+		query.NewQueryService(logger.With().Str("chain", "query").Logger(), httpClient, arcCfg),
+		policy.NewPolicyService(logger.With().Str("chain", "policy").Logger(), httpClient, arcCfg),
 	}
 }

--- a/engine/chain/interface.go
+++ b/engine/chain/interface.go
@@ -11,7 +11,13 @@ type QueryService interface {
 	QueryTransaction(ctx context.Context, txID string) (*chainmodels.TXInfo, error)
 }
 
+// PolicyService for querying policy.
+type PolicyService interface {
+	GetPolicy(ctx context.Context) (*chainmodels.Policy, error)
+}
+
 // Service related to the chain.
 type Service interface {
 	QueryService
+	PolicyService
 }

--- a/engine/chain/internal/policy/arc_mock_test.go
+++ b/engine/chain/internal/policy/arc_mock_test.go
@@ -1,0 +1,57 @@
+package policy_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
+)
+
+const (
+	wrongButReachable = "/wrong/url"
+	arcURL            = "https://arc.taal.com"
+	arcToken          = "mainnet_06770f425eb00298839a24a49cbdc02c"
+)
+
+func arcMockActivate(applyTimeout bool) *resty.Client {
+	transport := httpmock.NewMockTransport()
+	client := resty.New()
+	client.GetClient().Transport = transport
+
+	responder := func(status int, content string) func(req *http.Request) (*http.Response, error) {
+		return func(req *http.Request) (*http.Response, error) {
+			if applyTimeout {
+				time.Sleep(100 * time.Millisecond)
+			}
+			if req.Header.Get("Authorization") != arcToken {
+				return httpmock.NewStringResponse(http.StatusUnauthorized, ""), nil
+			}
+			res := httpmock.NewStringResponse(status, content)
+			res.Header.Set("Content-Type", "application/json")
+			return res, nil
+		}
+	}
+
+	transport.RegisterResponder("GET", fmt.Sprintf("%s/v1/policy", arcURL), responder(http.StatusOK, `{
+			"policy": {
+				"maxscriptsizepolicy": 100000000,
+				"maxtxsigopscountspolicy": 4294967295,
+				"maxtxsizepolicy": 100000000,
+				"miningFee": {
+					"bytes": 1000,
+					"satoshis": 1
+				}
+			},
+			"timestamp": "2024-10-02T07:36:33.589144918Z"
+		}`),
+	)
+
+	transport.RegisterResponder("GET", arcURL+wrongButReachable, responder(http.StatusNotFound, `{
+			"message": "no matching operation was found"
+		}`),
+	)
+
+	return client
+}

--- a/engine/chain/internal/policy/policy_service_test.go
+++ b/engine/chain/internal/policy/policy_service_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bitcoin-sv/spv-wallet/engine/spverrors"
 	"github.com/bitcoin-sv/spv-wallet/engine/tester"
 	"github.com/bitcoin-sv/spv-wallet/models/bsv"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,10 +104,9 @@ func TestPolicyServiceTimeouts(t *testing.T) {
 }
 
 func arcCfg(url, token string) chainmodels.ARCConfig {
-	deepSuffix, _ := uuid.NewUUID()
 	return chainmodels.ARCConfig{
 		URL:          url,
 		Token:        token,
-		DeploymentID: "spv-wallet-" + deepSuffix.String(),
+		DeploymentID: "spv-wallet-test-arc-connection",
 	}
 }

--- a/engine/chain/internal/policy/policy_service_test.go
+++ b/engine/chain/internal/policy/policy_service_test.go
@@ -1,4 +1,4 @@
-package query_test
+package policy_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	chainmodels "github.com/bitcoin-sv/spv-wallet/engine/chain/models"
 	"github.com/bitcoin-sv/spv-wallet/engine/spverrors"
 	"github.com/bitcoin-sv/spv-wallet/engine/tester"
+	"github.com/bitcoin-sv/spv-wallet/models/bsv"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -17,59 +18,39 @@ import (
 NOTE: switch httpClient to resty.New() tu call actual ARC server
 */
 
-func TestQueryService(t *testing.T) {
-	t.Run("QueryTransaction for MINED transaction", func(t *testing.T) {
+func TestPolicyService(t *testing.T) {
+	t.Run("Request for policy", func(t *testing.T) {
 		httpClient := arcMockActivate(false)
 
 		service := chain.NewChainService(tester.Logger(t), httpClient, arcCfg(arcURL, arcToken))
 
-		txInfo, err := service.QueryTransaction(context.Background(), minedTxID)
+		policy, err := service.GetPolicy(context.Background())
 
 		require.NoError(t, err)
-		require.NotNil(t, txInfo)
-		require.Equal(t, minedTxID, txInfo.TxID)
-		require.Equal(t, "MINED", string(txInfo.TXStatus))
-	})
-
-	t.Run("QueryTransaction for unknown transaction", func(t *testing.T) {
-		httpClient := arcMockActivate(false)
-
-		service := chain.NewChainService(tester.Logger(t), httpClient, arcCfg(arcURL, arcToken))
-
-		txInfo, err := service.QueryTransaction(context.Background(), unknownTxID)
-
-		require.NoError(t, err)
-		require.Nil(t, txInfo)
+		require.NotNil(t, policy)
+		require.Equal(t, 1000, policy.Content.MiningFee.Bytes)
+		require.Equal(t, bsv.Satoshis(1), policy.Content.MiningFee.Satoshis)
+		require.NotEmpty(t, policy.Timestamp)
 	})
 }
 
-func TestQueryServiceErrorCases(t *testing.T) {
+func TestPolicyServiceErrorCases(t *testing.T) {
 	errTestCases := map[string]struct {
-		txID      string
 		arcToken  string
 		arcURL    string
 		expectErr error
 	}{
-		"QueryTransaction for invalid transaction": {
-			txID:      invalidTxID,
-			arcToken:  arcToken,
-			arcURL:    arcURL,
-			expectErr: spverrors.ErrARCGenericError,
-		},
-		"QueryTransaction with wrong token": {
-			txID:      minedTxID,
+		"GetPolicy with wrong token": {
 			arcToken:  "wrong-token", //if you test it on actual ARC server, this test might fail if the ARC doesn't require token
 			arcURL:    arcURL,
 			expectErr: spverrors.ErrARCUnauthorized,
 		},
-		"QueryTransaction 404 endpoint but reachable": {
-			txID:      minedTxID,
+		"GetPolicy 404 endpoint but reachable": {
 			arcToken:  arcToken,
 			arcURL:    arcURL + wrongButReachable,
 			expectErr: spverrors.ErrARCUnreachable,
 		},
-		"QueryTransaction 404 endpoint with wrong arcURL": {
-			txID:      minedTxID,
+		"GetPolicy 404 endpoint with wrong arcURL": {
 			arcToken:  arcToken,
 			arcURL:    "wrong-url",
 			expectErr: spverrors.ErrARCUnreachable,
@@ -82,17 +63,17 @@ func TestQueryServiceErrorCases(t *testing.T) {
 
 			service := chain.NewChainService(tester.Logger(t), httpClient, arcCfg(tc.arcURL, tc.arcToken))
 
-			txInfo, err := service.QueryTransaction(context.Background(), tc.txID)
+			policy, err := service.GetPolicy(context.Background())
 
 			require.Error(t, err)
 			require.ErrorIs(t, err, tc.expectErr)
-			require.Nil(t, txInfo)
+			require.Nil(t, policy)
 		})
 	}
 }
 
-func TestQueryServiceTimeouts(t *testing.T) {
-	t.Run("QueryTransaction interrupted by ctx timeout", func(t *testing.T) {
+func TestPolicyServiceTimeouts(t *testing.T) {
+	t.Run("GetPolicy interrupted by ctx timeout", func(t *testing.T) {
 		httpClient := arcMockActivate(true)
 
 		service := chain.NewChainService(tester.Logger(t), httpClient, arcCfg(arcURL, arcToken))
@@ -100,7 +81,7 @@ func TestQueryServiceTimeouts(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1)
 		defer cancel()
 
-		txInfo, err := service.QueryTransaction(ctx, minedTxID)
+		txInfo, err := service.GetPolicy(ctx)
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, spverrors.ErrARCUnreachable)
@@ -108,13 +89,13 @@ func TestQueryServiceTimeouts(t *testing.T) {
 		require.Nil(t, txInfo)
 	})
 
-	t.Run("QueryTransaction interrupted by resty timeout", func(t *testing.T) {
+	t.Run("GetPolicy interrupted by resty timeout", func(t *testing.T) {
 		httpClient := arcMockActivate(true)
 		httpClient.SetTimeout(1 * time.Millisecond)
 
 		service := chain.NewChainService(tester.Logger(t), httpClient, arcCfg(arcURL, arcToken))
 
-		txInfo, err := service.QueryTransaction(context.Background(), minedTxID)
+		txInfo, err := service.GetPolicy(context.Background())
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, spverrors.ErrARCUnreachable)

--- a/engine/chain/internal/query/query_service_test.go
+++ b/engine/chain/internal/query/query_service_test.go
@@ -9,7 +9,6 @@ import (
 	chainmodels "github.com/bitcoin-sv/spv-wallet/engine/chain/models"
 	"github.com/bitcoin-sv/spv-wallet/engine/spverrors"
 	"github.com/bitcoin-sv/spv-wallet/engine/tester"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,10 +123,9 @@ func TestQueryServiceTimeouts(t *testing.T) {
 }
 
 func arcCfg(url, token string) chainmodels.ARCConfig {
-	deepSuffix, _ := uuid.NewUUID()
 	return chainmodels.ARCConfig{
 		URL:          url,
 		Token:        token,
-		DeploymentID: "spv-wallet-" + deepSuffix.String(),
+		DeploymentID: "spv-wallet-test-arc-connection",
 	}
 }

--- a/engine/chain/models/arc_config.go
+++ b/engine/chain/models/arc_config.go
@@ -1,0 +1,8 @@
+package chainmodels
+
+// ARCConfig is the configuration for the ARC API.
+type ARCConfig struct {
+	URL          string
+	Token        string
+	DeploymentID string
+}

--- a/engine/chain/models/policy.go
+++ b/engine/chain/models/policy.go
@@ -1,0 +1,27 @@
+package chainmodels
+
+import (
+	"time"
+
+	"github.com/bitcoin-sv/spv-wallet/models/bsv"
+)
+
+// FeeAmount indicating how many satoshis are paid for the given number of bytes in the transaction.
+type FeeAmount struct {
+	Bytes    int          `json:"bytes"`
+	Satoshis bsv.Satoshis `json:"satoshis"`
+}
+
+// PolicyContent is the actual policy values returned from ARC
+type PolicyContent struct {
+	MaxScriptSizePolicy     int       `json:"maxscriptsizepolicy"`
+	MaxTXSigOPSCountsPolicy int64     `json:"maxtxsigopscountspolicy"`
+	MaxTXSizePolicy         int       `json:"maxtxsizepolicy"`
+	MiningFee               FeeAmount `json:"miningFee"`
+}
+
+// Policy is the policy model returned from ARC
+type Policy struct {
+	Content   PolicyContent `json:"policy"`
+	Timestamp time.Time     `json:"timestamp"`
+}

--- a/engine/client.go
+++ b/engine/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bitcoin-sv/go-paymail"
 	"github.com/bitcoin-sv/go-paymail/server"
 	"github.com/bitcoin-sv/spv-wallet/engine/chain"
+	chainmodels "github.com/bitcoin-sv/spv-wallet/engine/chain/models"
 	"github.com/bitcoin-sv/spv-wallet/engine/chainstate"
 	"github.com/bitcoin-sv/spv-wallet/engine/cluster"
 	"github.com/bitcoin-sv/spv-wallet/engine/datastore"
@@ -51,14 +52,8 @@ type (
 		taskManager             *taskManagerOptions    // Configuration options for the TaskManager (TaskQ, etc.)
 		userAgent               string                 // User agent for all outgoing requests
 		chainService            chain.Service          // Chain service
-		arcConfig               arcConfig              // Configuration for ARC
+		arcConfig               chainmodels.ARCConfig  // Configuration for ARC
 		txCallbackConfig        *txCallbackConfig      // Configuration for TX callback received from ARC; disabled if nil
-	}
-
-	arcConfig struct {
-		URL          string // URL for the ARC
-		Token        string // Token for the ARC
-		DeploymentID string // Deployment ID for the ARC
 	}
 
 	txCallbackConfig struct {

--- a/engine/client_internal.go
+++ b/engine/client_internal.go
@@ -206,7 +206,7 @@ func (c *Client) loadTransactionDraftService() error {
 func (c *Client) loadChainService() {
 	if c.options.chainService == nil {
 		logger := c.Logger().With().Str("subservice", "chain").Logger()
-		c.options.chainService = chain.NewChainService(logger, resty.New(), c.options.arcConfig.URL, c.options.arcConfig.Token, c.options.arcConfig.DeploymentID)
+		c.options.chainService = chain.NewChainService(logger, resty.New(), c.options.arcConfig)
 	}
 }
 

--- a/engine/client_options.go
+++ b/engine/client_options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitcoin-sv/go-broadcast-client/broadcast"
 	"github.com/bitcoin-sv/go-paymail"
 	"github.com/bitcoin-sv/go-paymail/server"
+	chainmodels "github.com/bitcoin-sv/spv-wallet/engine/chain/models"
 	"github.com/bitcoin-sv/spv-wallet/engine/chainstate"
 	"github.com/bitcoin-sv/spv-wallet/engine/cluster"
 	"github.com/bitcoin-sv/spv-wallet/engine/datastore"
@@ -644,7 +645,7 @@ func WithCallback(callbackURL string, callbackToken string) ClientOps {
 // WithARC set ARC url params
 func WithARC(url, token, deploymentID string) ClientOps {
 	return func(c *clientOptions) {
-		c.arcConfig = arcConfig{
+		c.arcConfig = chainmodels.ARCConfig{
 			URL:          url,
 			Token:        token,
 			DeploymentID: deploymentID,


### PR DESCRIPTION
> NOTE: I'm aware that there are places where the code is very similar in `QueryService` & `PolicyService`.
> I'm gonna unify things after I finish implementing `BroadcastService`. 

## AI generated summary

This pull request introduces a new `PolicyService` and refactors the existing `QueryService` to use a unified `ARCConfig` struct for configuration. Additionally, it includes tests for the new `PolicyService` and updates tests for the `QueryService`.

### Key Changes:

#### New Features:
* [`engine/chain/internal/policy/policy_service.go`](diffhunk://#diff-959bfbdf9deaff6386a2b0c2006c54722696cfdc92872b960803629b41655cc8R1-R78): Introduced `PolicyService` for querying policy from the ARC server.
* [`engine/chain/internal/policy/policy_service_test.go`](diffhunk://#diff-e46fc7ae06bbf875ebf0ebdf889a054d1ce77ea6a1c13da2dd4a17919764b5b8R1-R114): Added tests for `PolicyService`, including error cases and timeouts.

#### Refactoring:
* [`engine/chain/models/arc_config.go`](diffhunk://#diff-8fe766db4e355561176a08dada69c27f7fe19b8ebf23437c29ec553b140c714aR1-R8): Created `ARCConfig` struct to hold ARC API configuration.
* [`engine/chain/chain_service.go`](diffhunk://#diff-31c2f462dcc0321b0c576079b4309bf2e50f720333016ad708804a719e2bf03aR4-R20): Updated `NewChainService` to use `ARCConfig` and added `PolicyService`.
* [`engine/chain/internal/query/query_service.go`](diffhunk://#diff-93a2543c7ea68cd1ab43c0e00936c8955fc4e2fbf570c0510af6ffee06ef08a7L21-R29): Refactored `QueryService` to use `ARCConfig` for configuration. [[1]](diffhunk://#diff-93a2543c7ea68cd1ab43c0e00936c8955fc4e2fbf570c0510af6ffee06ef08a7L21-R29) [[2]](diffhunk://#diff-93a2543c7ea68cd1ab43c0e00936c8955fc4e2fbf570c0510af6ffee06ef08a7L47-R51) [[3]](diffhunk://#diff-93a2543c7ea68cd1ab43c0e00936c8955fc4e2fbf570c0510af6ffee06ef08a7R80-R82)
* `engine/client.go`, `engine/client_internal.go`, `engine/client_options.go`: Updated client configuration to use `ARCConfig`. [[1]](diffhunk://#diff-a92e280e12097c7a058672dc80551529f7dfed8e9001beeff1109d518a0e89d0R10) [[2]](diffhunk://#diff-a92e280e12097c7a058672dc80551529f7dfed8e9001beeff1109d518a0e89d0L54-L63) [[3]](diffhunk://#diff-921c3dfbdb1e22318f59271adcea08e24b27734cd3f05f2fc8aa707f4c66e236L209-R209) [[4]](diffhunk://#diff-bd2565df235a1850956e6aaeb6ebbcc9793ed1851e814dc9b96acf4192f8a6a4R13) [[5]](diffhunk://#diff-bd2565df235a1850956e6aaeb6ebbcc9793ed1851e814dc9b96acf4192f8a6a4L647-R648)

#### Testing:
* [`engine/chain/internal/policy/arc_mock_test.go`](diffhunk://#diff-634539ddfe4915ad8d471f8db90d1a6bc07924869e2909a8ab7293a16f96ff52R1-R57): Added mock tests for `PolicyService`.
* [`engine/chain/internal/query/query_service_test.go`](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602R9): Updated tests for `QueryService` to use `ARCConfig`. [[1]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602R9) [[2]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L23-R24) [[3]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L36-R37) [[4]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L60-R61) [[5]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L82-R83) [[6]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L97-R98) [[7]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L114-R115) [[8]](diffhunk://#diff-269d54f5b170c180b918a38c2f1641f57fc81bbf91328cd8b973c1232e2af602L125-R132)

<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/spv-wallet/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/spv-wallet/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [x] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [x] 💾 PR was issued based on the Github or Jira issue.

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
