### PR TITLE
fix(SPV-1357): webhook tests

### DIFF
--- a/engine/notifications/webhook_manager.go
+++ b/engine/notifications/webhook_manager.go
@@ -26,6 +26,7 @@ type WebhookManager struct {
 	banMsg           chan string // url
 	notifications    *Notifications
 	logger           *zerolog.Logger
+	endMsg           chan bool
 }
 
 // NewWebhookManager creates a new WebhookManager. It starts a goroutine which checks for webhook updates.
@@ -41,6 +42,7 @@ func NewWebhookManager(ctx context.Context, logger *zerolog.Logger, notification
 		updateMsg:        make(chan bool),
 		banMsg:           make(chan string),
 		logger:           logger,
+		endMsg:           make(chan bool),
 	}
 
 	go manager.checkForUpdates()
@@ -50,7 +52,11 @@ func NewWebhookManager(ctx context.Context, logger *zerolog.Logger, notification
 
 // Stop stops the WebhookManager.
 func (w *WebhookManager) Stop() {
+	w.ticker.Stop()
 	w.cancelAllFunc()
+
+	<-w.endMsg
+	w.logger.Info().Msg("WebhookManager stopped")
 }
 
 // Subscribe subscribes to a webhook. It adds the webhook to the database and starts a notifier for it.
@@ -100,7 +106,7 @@ func (w *WebhookManager) GetAll(ctx context.Context) ([]ModelWebhook, error) {
 
 func (w *WebhookManager) checkForUpdates() {
 	defer func() {
-		w.logger.Info().Msg("WebhookManager stopped")
+		w.endMsg <- true
 		if err := recover(); err != nil {
 			w.logger.Warn().Msgf("WebhookManager failed: %v", err)
 		}

--- a/engine/notifications/webhook_manager.go
+++ b/engine/notifications/webhook_manager.go
@@ -42,7 +42,7 @@ func NewWebhookManager(ctx context.Context, logger *zerolog.Logger, notification
 		updateMsg:        make(chan bool),
 		banMsg:           make(chan string),
 		logger:           logger,
-		endMsg:           make(chan bool),
+		endMsg:           make(chan bool, 1),
 	}
 
 	go manager.checkForUpdates()
@@ -108,7 +108,7 @@ func (w *WebhookManager) checkForUpdates() {
 	defer func() {
 		w.endMsg <- true
 		if err := recover(); err != nil {
-			w.logger.Warn().Msgf("WebhookManager failed: %v", err)
+			w.logger.Fatal().Msgf("WebhookManager failed: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
Checked 4 times on GithubActions, and it works (one failed but because of other reason)
https://github.com/bitcoin-sv/spv-wallet/actions/runs/12685363196

<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [ ] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/spv-wallet/blob/main/.github/CODE_STANDARDS.md)
- [ ] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/spv-wallet/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [ ] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
